### PR TITLE
Use Ecto Poison Decimal Encoder implementation.

### DIFF
--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -1,10 +1,10 @@
-defimpl Poison.Encoder, for: Decimal do
-  @doc """
-  Implements custom Decimal encoder that allows serialization of Decimal objects
-  into JSON using Poison.
-  """
-
-  def encode(decimal, _options) do
-    Decimal.to_string(decimal)
+if Code.ensure_loaded?(Poison) do
+  defimpl Poison.Encoder, for: Decimal do
+    @doc """
+    Implements custom Decimal encoder that allows serialization of Decimal objects
+    into JSON using Poison.
+    Definition copied from Ecto
+    """
+    def encode(decimal, _opts), do: <<?", Decimal.to_string(decimal)::binary, ?">>
   end
 end

--- a/lib/poison/encoder.ex
+++ b/lib/poison/encoder.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Poison) do
+if Code.ensure_loaded?(Poison) and not Code.ensure_loaded?(Ecto) do
   defimpl Poison.Encoder, for: Decimal do
     @doc """
     Implements custom Decimal encoder that allows serialization of Decimal objects


### PR DESCRIPTION
Decided to change implementation of Decimal Encoder to match the implementation used in Ecto. Ecto overwrites this anyway, but I wouldn't want this to somehow get loaded later than Ecto and interfere with proper work of Ecto.
