### PR TITLE
add verbosity param for getblock

### DIFF
--- a/lib/gold.ex
+++ b/lib/gold.ex
@@ -175,14 +175,15 @@ defmodule Gold do
   end
 
   @doc """
-  https://bitcoin.org/en/developer-reference#getblock
+  https://developer.bitcoin.org/reference/rpc/getblock.html
   """
-  def getblock(name, hash) do
-    call(name, {:getblock, [hash]})
+  def getblock(name, hash, verbosity \\ nil) do
+    params = if verbosity, do: [hash, verbosity], else: [hash]
+    call(name, {:getblock, params})
   end
 
-  def getblock!(name, hash) do
-    {:ok, block} = getblock(name, hash)
+  def getblock!(name, hash, verbosity \\ nil) do
+    {:ok, block} = getblock(name, hash, verbosity)
     block
   end
 


### PR DESCRIPTION
`getblock` has a second param `verbosity`.

https://developer.bitcoin.org/reference/rpc/getblock.html

```
getblock "blockhash" ( verbosity )
```

If verbosity is 0, returns a string that is serialized, hex-encoded data for block ‘hash’.

If verbosity is 1, returns an Object with information about block ‘hash’.

If verbosity is 2, returns an Object with information about block ‘hash’ and information about each transaction.
